### PR TITLE
Change stricmp to strcqsecmp

### DIFF
--- a/Constellation.h
+++ b/Constellation.h
@@ -47,6 +47,7 @@
 #define DEFAULT_SUBSCRIPTION_TIMEOUT 60000
 #define DEFAULT_SUBSCRIPTION_LIMIT 1
 #define SUBSCRIPTIONID_SIZE 36
+#define stricmp strcasecmp
 
 template<typename TNetworkClass>
 class Constellation


### PR DESCRIPTION
Strange behavior with Wemos D1 Mini Lite, when I add this line #50, was working...